### PR TITLE
Basic Audio Features Added

### DIFF
--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideShowFileManager.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideShowFileManager.java
@@ -32,4 +32,13 @@ public class SlideShowFileManager {
         }
         return imagesFolder;
     }
+    
+       public static File getAudioFolder(String slideshowName) {
+        File slideshowDir = getSlideshowDirectory(slideshowName); // Use getSlideshowDirectory
+        File audioFolder = new File(slideshowDir, "audio");
+        if (!audioFolder.exists()) {
+            audioFolder.mkdirs();
+        }
+        return audioFolder;
+    }
 }

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.form
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.form
@@ -84,12 +84,12 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="addAudioFileMenuItemActionPerformed"/>
               </Events>
             </MenuItem>
-            <MenuItem class="javax.swing.JMenuItem" name="jMenuItem1">
+            <MenuItem class="javax.swing.JMenuItem" name="playAudioMenuItem">
               <Properties>
                 <Property name="text" type="java.lang.String" value="Play Audio"/>
               </Properties>
               <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jMenuItem1ActionPerformed"/>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="playAudioMenuItemActionPerformed"/>
               </Events>
             </MenuItem>
           </SubComponents>

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.form
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.form
@@ -84,6 +84,14 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="addAudioFileMenuItemActionPerformed"/>
               </Events>
             </MenuItem>
+            <MenuItem class="javax.swing.JMenuItem" name="jMenuItem1">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Play Audio"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jMenuItem1ActionPerformed"/>
+              </Events>
+            </MenuItem>
           </SubComponents>
         </Menu>
       </SubComponents>

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.form
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.form
@@ -71,6 +71,21 @@
             </MenuItem>
           </SubComponents>
         </Menu>
+        <Menu class="javax.swing.JMenu" name="audioMenu">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Audio"/>
+          </Properties>
+          <SubComponents>
+            <MenuItem class="javax.swing.JMenuItem" name="addAudioFileMenuItem">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Add Audio File"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="addAudioFileMenuItemActionPerformed"/>
+              </Events>
+            </MenuItem>
+          </SubComponents>
+        </Menu>
       </SubComponents>
     </Menu>
   </NonVisualComponents>

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
@@ -117,7 +117,13 @@ public class SlideshowCreator extends javax.swing.JFrame {
 
             JSONObject json = new JSONObject(jsonString);
             JSONArray slides = json.getJSONArray("slides"); // Corrected line: Use "slides"
-            List<File> imageFiles = new ArrayList<>();
+            //List<File> imageFiles = new ArrayList<>();
+            if (json.has("audio")) {
+                JSONArray audioArray = json.getJSONArray("audio");
+                for (int i = 0; i < audioArray.length(); i++) {
+                    audioFiles.add(new File(audioArray.getString(i)));
+                }
+            }
 
             for (int i = 0; i < slides.length(); i++) {
                 JSONObject slideObject = slides.getJSONObject(i);
@@ -126,6 +132,8 @@ public class SlideshowCreator extends javax.swing.JFrame {
                 imageFiles.add(imageFile);
             }
             updateImageFiles(imageFiles);
+            
+            
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
@@ -255,7 +255,7 @@ public class SlideshowCreator extends javax.swing.JFrame {
         DarkMode = new javax.swing.JMenuItem();
         audioMenu = new javax.swing.JMenu();
         addAudioFileMenuItem = new javax.swing.JMenuItem();
-        jMenuItem1 = new javax.swing.JMenuItem();
+        playAudioMenuItem = new javax.swing.JMenuItem();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
         setTitle("Slideshow Creator");
@@ -346,13 +346,13 @@ public class SlideshowCreator extends javax.swing.JFrame {
         });
         audioMenu.add(addAudioFileMenuItem);
 
-        jMenuItem1.setText("Play Audio");
-        jMenuItem1.addActionListener(new java.awt.event.ActionListener() {
+        playAudioMenuItem.setText("Play Audio");
+        playAudioMenuItem.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jMenuItem1ActionPerformed(evt);
+                playAudioMenuItemActionPerformed(evt);
             }
         });
-        audioMenu.add(jMenuItem1);
+        audioMenu.add(playAudioMenuItem);
 
         menuBar.add(audioMenu);
 
@@ -475,7 +475,7 @@ public class SlideshowCreator extends javax.swing.JFrame {
         }
     }//GEN-LAST:event_addAudioFileMenuItemActionPerformed
 
-    private void jMenuItem1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jMenuItem1ActionPerformed
+    private void playAudioMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_playAudioMenuItemActionPerformed
         if (audioFiles != null && !audioFiles.isEmpty()) {
             Thread thread = new Thread(new Runnable() {
                 @Override
@@ -515,7 +515,7 @@ public class SlideshowCreator extends javax.swing.JFrame {
         } else {
             System.out.println("No audio files available.");
         }
-    }//GEN-LAST:event_jMenuItem1ActionPerformed
+    }//GEN-LAST:event_playAudioMenuItemActionPerformed
 
     public void addAudioFile(File audioFile) {
     if (audioFile != null && audioFile.getName().toLowerCase().endsWith(".wav")) {
@@ -722,9 +722,9 @@ public class SlideshowCreator extends javax.swing.JFrame {
     private javax.swing.JMenuItem exitMenuItem;
     private javax.swing.JLabel imageLabel;
     private javax.swing.JMenu jMenu;
-    private javax.swing.JMenuItem jMenuItem1;
     private javax.swing.JMenuBar menuBar;
     private javax.swing.JMenuItem openPreviousSlideMenuItem;
+    private javax.swing.JMenuItem playAudioMenuItem;
     private javax.swing.JButton presenterButton;
     private javax.swing.JMenuItem saveMenuItem;
     // End of variables declaration//GEN-END:variables

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
@@ -34,7 +34,9 @@ import java.awt.image.BufferedImage;
 public class SlideshowCreator extends javax.swing.JFrame {
     
     private List<File> imageFiles = new ArrayList<>(); // image list
-    private int index = 0; // image list index
+    private List<File> audioFiles = new ArrayList<>(); // audio list
+    private int index = 0; // image list index (now defunct and can likely be removed)
+    private int audioIndex = 0; // tracks current audio track
     private Preferences prefs = Preferences.userNodeForPackage(SlideshowCreator.class);
     private List<Slide> slides = new ArrayList<>();
     private SlideShowFileManager slideShowFileManager = new SlideShowFileManager();
@@ -250,6 +252,8 @@ public class SlideshowCreator extends javax.swing.JFrame {
         ThemesButton = new javax.swing.JMenu();
         LightMode = new javax.swing.JMenuItem();
         DarkMode = new javax.swing.JMenuItem();
+        audioMenu = new javax.swing.JMenu();
+        addAudioFileMenuItem = new javax.swing.JMenuItem();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
         setTitle("Slideshow Creator");
@@ -329,6 +333,18 @@ public class SlideshowCreator extends javax.swing.JFrame {
         ThemesButton.add(DarkMode);
 
         menuBar.add(ThemesButton);
+
+        audioMenu.setText("Audio");
+
+        addAudioFileMenuItem.setText("Add Audio File");
+        addAudioFileMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                addAudioFileMenuItemActionPerformed(evt);
+            }
+        });
+        audioMenu.add(addAudioFileMenuItem);
+
+        menuBar.add(audioMenu);
 
         setJMenuBar(menuBar);
 
@@ -436,6 +452,30 @@ public class SlideshowCreator extends javax.swing.JFrame {
         System.exit(0); // Terminate the application
     }//GEN-LAST:event_exitMenuItemActionPerformed
 
+    private void addAudioFileMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_addAudioFileMenuItemActionPerformed
+        JFileChooser fileChooser = new JFileChooser();
+        fileChooser.setMultiSelectionEnabled(true);
+        fileChooser.setFileFilter(new FileNameExtensionFilter("WAV Audio Files", "wav"));
+
+        int returnValue = fileChooser.showOpenDialog(null);
+        if (returnValue == JFileChooser.APPROVE_OPTION) {
+            for (File file : fileChooser.getSelectedFiles()) {
+                addAudioFile(file);
+            }
+        }
+    }//GEN-LAST:event_addAudioFileMenuItemActionPerformed
+
+    public void addAudioFile(File audioFile) {
+    if (audioFile != null && audioFile.getName().toLowerCase().endsWith(".wav")) {
+        audioFiles.add(audioFile);
+        if (audioFiles.size() == 1) {
+            audioIndex = 0; // Set to first file if it's the first one added
+        }
+    } else {
+        System.out.println("Invalid file format. Only .wav files are supported.");
+    }
+}
+    
     private JFileChooser createFileChooser(int selectionMode, boolean multiSelection) {
         JFileChooser fileChooser = new JFileChooser();
         fileChooser.setFileSelectionMode(selectionMode);
@@ -623,6 +663,8 @@ public class SlideshowCreator extends javax.swing.JFrame {
     private javax.swing.JMenuItem LightMode;
     private javax.swing.JMenu ThemesButton;
     private javax.swing.JPanel TimelinePanel;
+    private javax.swing.JMenuItem addAudioFileMenuItem;
+    private javax.swing.JMenu audioMenu;
     private javax.swing.JMenuItem createNewSlideMenuItem;
     private javax.swing.JMenuItem exitMenuItem;
     private javax.swing.JLabel imageLabel;

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
@@ -94,10 +94,9 @@ public class SlideshowCreator extends javax.swing.JFrame {
         String filePath = file.getAbsolutePath();
         String slideshowName = file.getName().replaceFirst("[.][^.]+$", ""); // Extract name without extension
         List<Slide> slides = getSlides();
-        String audioPath = getAudioPath();
         boolean loop = isLoop();
 
-        SlideshowSettingsSaver.saveSettingsToJson(filePath, slideshowName, slides, audioPath, loop);
+        SlideshowSettingsSaver.saveSettingsToJson(filePath, slideshowName, slides, audioFiles, loop);
     }
        
     private void loadSlideshowSettings(File file) {
@@ -219,16 +218,6 @@ public class SlideshowCreator extends javax.swing.JFrame {
         imageLabel.setIcon(resizedIcon);
         imageLabel.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
         imageLabel.setVerticalAlignment(javax.swing.SwingConstants.CENTER);
-    }
-    
-    private void displaySlide(int index) {
-        if (index >= 0 && index < slides.size()) {
-            Slide slide = slides.get(index);
-            String imagePath = slide.getImagePath();
-            ImageIcon imageIcon = new ImageIcon(imagePath);
-            Image image = imageIcon.getImage().getScaledInstance(imageLabel.getWidth(), imageLabel.getHeight(), Image.SCALE_SMOOTH);
-            imageLabel.setIcon(new ImageIcon(image));
-        }
     }
     
     /**
@@ -557,6 +546,7 @@ public class SlideshowCreator extends javax.swing.JFrame {
             File targetFile = new File(targetFolder, selectedFile.getName());
             targetFile = avoidDuplicateFileNames(targetFile, selectedFile, targetFolder);
             copyImageFile(selectedFile, newImages, targetFile);
+                       
         }
         updateImageFiles(newImages);
     }

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowSettingsSaver.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowSettingsSaver.java
@@ -4,6 +4,7 @@
  */
 package com.team5.senior_project;
 
+import java.io.File;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import java.io.FileWriter;
@@ -12,13 +13,17 @@ import java.util.List;
 
 public class SlideshowSettingsSaver {
 
-    public static void saveSettingsToJson(String filePath, String slideshowName, List<Slide> slides, String audioPath, boolean loop) {
+    public static void saveSettingsToJson(String filePath, String slideshowName, List<Slide> slides, List<File> audioFiles, boolean loop) {
         JSONObject slideshowJson = new JSONObject();
         slideshowJson.put("name", slideshowName);
         slideshowJson.put("loop", loop);
 
-        if (audioPath != null && !audioPath.isEmpty()) {
-            slideshowJson.put("audio", audioPath);
+        if (audioFiles != null && !audioFiles.isEmpty()) {
+            JSONArray audioArray = new JSONArray();
+            for (File audioFile : audioFiles) {
+                audioArray.put(audioFile.getAbsolutePath());
+            }
+            slideshowJson.put("audio", audioArray);
         }
 
         JSONArray slidesArray = new JSONArray();


### PR DESCRIPTION
There is now a new "Audio" menu tab. Within are two menuItem's: "**Add Audio**", "**Play Audio**"
**Add Audio** allows the user to add .wav files to their slideshow. These file locations get written into the .json for saving and loading back in if user were to load the slideshow at a later time into the editor.
**Play Audio** first checks if audio files are even in the project. If they are, it creates a separate thread that sequentially plays every audio in the project. Threading was necessary so users can continue editing slides while audio plays.

Next features to add: Probably some way to remove audio files, probably some way to modify order of audio files. I may wait until we have some UI changes for these features though.

Also within the SlideshowSetting function I removed a line that created a new ArrayList object called imageFiles. I removed this line since this object already exists as a global object. Now we can reference imageFiles anywhere for the list of images if needed anywhere in the program when a previously made slideshow is loaded into the program. 
In essence this loads imageFiles the same way no matter if it's a new slideshow or an old slideshow being loaded into the editor.