### PR TITLE
Resolved several of professor James issues

### DIFF
--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowCreator.java
@@ -770,7 +770,7 @@ public class SlideshowCreator extends javax.swing.JFrame {
             int interval = json.getInt("interval");
 
             // Update the settings panel (ensure these methods exist in SettingsPanel)
-            settingsPanel.setPlaybackMode(loop ? "Loop Slideshow" : "Single Play");
+            settingsPanel.setPlaybackMode(loop ? "Loop Slideshow" : "Play Once and End");
             settingsPanel.setSelectedMode(mode);
             settingsPanel.setIntervalText(String.valueOf(interval));
 

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowPresenter.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowPresenter.java
@@ -164,6 +164,16 @@ public class SlideshowPresenter extends javax.swing.JFrame {
     }
     
     private void transitionToNextSlide() {
+
+        if (!canLoop && index[0] >= imageFiles.length - 1) {
+            // We’re on the final slide and looping is disabled – halt the show.
+            if (slideShowTimer != null) {
+                slideShowTimer.stop();
+            }
+            System.out.println("Reached final slide – auto‑mode halted.");
+            return;
+        }
+
         if (slideshowStopped) {
             return;
         }
@@ -182,14 +192,14 @@ public class SlideshowPresenter extends javax.swing.JFrame {
         BufferedImage prevBuffered = Transition.toBufferedImage(new ImageIcon(imageFiles[index[0]].getAbsolutePath()).getImage());
         BufferedImage nextBuffered = Transition.toBufferedImage(new ImageIcon(imageFiles[nextIndex].getAbsolutePath()).getImage());
         transitionManager.doTransition(prevBuffered, nextBuffered, imageLabel,
-        nextTransition, transTime, () -> {
+                nextTransition, transTime, () -> {
             index[0] = nextIndex;
             int totalTime = fixedDuration + transTime;
             System.out.println("Transition complete. Now showing slide index: "
-            + index[0] + " | Total time: " + totalTime + " ms");
+                    + index[0] + " | Total time: " + totalTime + " ms");
 
-            if (!paused) {        // Don’t restart cycle while paused
-            startAutoSlideCycle();
+            if (!paused && (canLoop || index[0] < imageFiles.length - 1)) {
+                startAutoSlideCycle();
             }
         });
     }

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowPresenter.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowPresenter.java
@@ -368,34 +368,42 @@ public class SlideshowPresenter extends javax.swing.JFrame {
     }
     
     /**
-     * Toggles pause/resume state. When paused, the timer stops and the "Paused" overlay is shown;
-     * when resumed, the timer restarts and the overlay is hidden.
+     * Toggles pause/resume.
+     * – In manual mode: pauses/resumes audio (and any running transition) only.
+     * – In auto mode: also stops/starts the slide‑advance timer.
      */
     private void togglePause() {
-        if (!autoMode) return;   // nothing to pause in manual mode
-    
-        if (paused) {            // ------- RESUME -------
+        // ---------- Manual mode ----------
+        if (!autoMode) {
+            if (paused) {                 // RESUME
+                transitionManager.resume();
+                resumeAudio();
+            } else {                      // PAUSE
+                transitionManager.pause();
+                pauseAudio();
+            }
+            paused = !paused;             // flip state
+            return;                       // done – no timer to manage
+        }
+
+        // ---------- Auto mode ----------
+        if (paused) {                     // RESUME
             paused = false;
-    
-            transitionManager.resume();           // Continue any running animation
+            transitionManager.resume();
             resumeAudio();
-    
-            // Only restart slide cycle if we are *not* in the middle of a transition
             if (!transitionInProgress) {
-                startAutoSlideCycle();
+                startAutoSlideCycle();    // restart slide timer
             }
-    
-        } else {                 // ------- PAUSE -------
+        } else {                          // PAUSE
             if (slideShowTimer != null) {
-                slideShowTimer.stop();            // stop countdown
+                slideShowTimer.stop();    // stop countdown
             }
-            transitionManager.pause();            // freeze animation
+            transitionManager.pause();
             pauseAudio();
-    
             paused = true;
         }
     }
-    
+
     private void pauseAudio() {
         synchronized (audioLock) {
             audioPaused = true;

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowPresenter.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowPresenter.java
@@ -34,7 +34,6 @@ public class SlideshowPresenter extends javax.swing.JFrame {
     private boolean canLoop;
     private TransitionType[] slideTransitions;
     private boolean paused = false;
-    private JLabel pausedLabel;
     private final Transition transitionManager = new Transition();
     private Thread audioThread;
     private boolean audioPaused = false;
@@ -65,21 +64,6 @@ public class SlideshowPresenter extends javax.swing.JFrame {
         imageLabel.setVerticalAlignment(SwingConstants.CENTER);
         getContentPane().setLayout(new BorderLayout());
         getContentPane().add(imageLabel, BorderLayout.CENTER);
-        // Setup paused overlay.
-        pausedLabel = new JLabel("Paused", SwingConstants.CENTER);
-        pausedLabel.setFont(new java.awt.Font("SansSerif", java.awt.Font.BOLD, 48));
-        pausedLabel.setForeground(Color.WHITE);
-        pausedLabel.setOpaque(false);
-        pausedLabel.setVisible(false);
-        this.getLayeredPane().add(pausedLabel, new Integer(200));
-        pausedLabel.setBounds(0, 0, getWidth(), getHeight());
-        // Update pausedLabel bounds when the frame is resized.
-        addComponentListener(new ComponentAdapter() {
-            @Override
-            public void componentResized(ComponentEvent e) {
-                pausedLabel.setBounds(0, 0, getWidth(), getHeight());
-            }
-        });
     }
 
     /**
@@ -392,7 +376,6 @@ public class SlideshowPresenter extends javax.swing.JFrame {
     
         if (paused) {            // ------- RESUME -------
             paused = false;
-            pausedLabel.setVisible(false);
     
             transitionManager.resume();           // Continue any running animation
             resumeAudio();
@@ -410,7 +393,6 @@ public class SlideshowPresenter extends javax.swing.JFrame {
             pauseAudio();
     
             paused = true;
-            pausedLabel.setVisible(true);
         }
     }
     

--- a/Senior_Project/src/main/java/com/team5/senior_project/SlideshowSettingsSaver.java
+++ b/Senior_Project/src/main/java/com/team5/senior_project/SlideshowSettingsSaver.java
@@ -10,7 +10,8 @@ import org.json.JSONObject;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
-
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class SlideshowSettingsSaver {
     
@@ -28,6 +29,10 @@ public class SlideshowSettingsSaver {
      */
     public static void saveSettingsToJson(String filePath, String slideshowName, List<Slide> slides, List<File> audioFiles, 
                                           boolean loop, String mode, int interval, List<String> transitions) {
+        
+        // Treat the JSON’s directory as the root for relative paths
+        Path rootDir = Paths.get(filePath).toAbsolutePath().getParent();
+        
         JSONObject slideshowJson = new JSONObject();
         slideshowJson.put("name", slideshowName);
         slideshowJson.put("loop", loop);
@@ -38,7 +43,9 @@ public class SlideshowSettingsSaver {
         if (audioFiles != null && !audioFiles.isEmpty()) {
             JSONArray audioArray = new JSONArray();
             for (File audioFile : audioFiles) {
-                audioArray.put(audioFile.getAbsolutePath());
+                // Store path relative to rootDir
+                Path relAudio = rootDir.relativize(audioFile.toPath().toAbsolutePath());
+                audioArray.put(relAudio.toString().replace("\\", "/"));
             }
             slideshowJson.put("audio", audioArray);
         }
@@ -47,7 +54,10 @@ public class SlideshowSettingsSaver {
         JSONArray slidesArray = new JSONArray();
         for (int i = 0; i < slides.size(); i++) {
             JSONObject slideJson = new JSONObject();
-            slideJson.put("image", slides.get(i).getImagePath());
+            // Ssave image path relative to rootDir
+            Path relImg = rootDir.relativize(Paths.get(slides.get(i).getImagePath()).toAbsolutePath());
+            slideJson.put("image", relImg.toString().replace("\\", "/"));
+            
             // Attach the transition for this slide if available.
             if (transitions != null && transitions.size() > i) {
                 slideJson.put("transition", transitions.get(i));


### PR DESCRIPTION
### PR: Loop‑control, cross‑machine playback & safe‑pause fixes

This PR tackles three issues raised by **Prof James**:

| Issue | Status | Note |
|-------|--------|------|
| **Fix slideshow “Loop” / “Play Once”** (`bug`) | **✔ Resolved** | Slideshow now halts on the last slide when looping is off. |
| **Saved presentations must run on other machines** (`enhancement`) | **✔ Resolved** | Runtime no longer relies on hard‑coded system paths—everything now uses relative paths, so saved slideshows play correctly on any machine. |
| **Pause ignored while a transition is running** (`bug / enhancement`) | **✔ Resolved** | You can pause‑and‑resume mid‑transition without errors. |
| **Can now pause in manual mode** (`bug / enhancement`) | **✔ Resolved** | Audio will stop playing after hitting the space bar in manual mode |

---

#### Key changes
* **Restored single‑run mode** – respects `loop =false`; stops cleanly at final slide.  
* **Transition‑aware pause** – animations and audio freeze & resume safely.  
* **Overlay removed** – deleted `pausedLabel`; null‑checks eliminated the NPE on other machines.

---

#### Verification
1. Open a slideshow in **auto‑mode**, `loop =false`.  
2. It advances through all slides once and stops—no restart.  
3. During any transition press **space**: animation/audio freeze; press again to resume.  
4. Share your slideshow file with another machine can try and open the slides on the new machine. All images, transitions and settings should be applied and function. 

Issues:
- Closes #65
- Closes #64
- Closes #62
- Closes #63